### PR TITLE
updated broken nwjs link

### DIFF
--- a/omori-apple-silicon-patch.command
+++ b/omori-apple-silicon-patch.command
@@ -29,7 +29,7 @@ cd $TMPFOLDER;
 mv "${OMORI}/OMORI.app" "./OMORI.original.app";
 
 echo "Downloading nwjs.."
-curl -# -o nwjs.zip https://dl.nwjs.io/live-build/nw77/20230531-164722/7323cc662/v0.77.0/nwjs-v0.77.0-osx-arm64.zip
+curl -# -o nwjs.zip https://dl.nwjs.io/v0.77.0/nwjs-v0.77.0-osx-arm64.zip
 echo "Downloading node polyfill patch.."
 curl -#L -o node-polyfill-patch.js https://github.com/SnowpMakes/omori-apple-silicon/releases/download/v1.1.0/node-polyfill-patch.js
 echo "Downloading greenworks patches.."


### PR DESCRIPTION
v0.77.0 is no longer under /live-build/ in exchange for nwjs v0.84.x and v0.85.x
- updated the nwjs download link to v0.77.0's new location
